### PR TITLE
Create daemon idtokens after configure

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -25,7 +25,8 @@
     owner: root
     group: root
 - name: Create Daemon Token
-  command: "condor_token_create -identity condor@{{ condor_host }} > /etc/condor/tokens.d/condor@{{ condor_host }}"
+  shell: 
+    cmd: "condor_token_create -identity condor@{{ condor_host }} > /etc/condor/tokens.d/condor@{{ condor_host }}"
 - file: 
     path: "/etc/condor/tokens.d/condor@{{ condor_host }}"
     mode: 0600

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,6 +24,11 @@
     path: "{{ condor_pool_password_file_path }}"
     owner: root
     group: root
+- name: Create Daemon Token
+  command: "condor_token_create -identity condor@{{ condor_host }} > /etc/condor/tokens.d/condor@{{ condor_host }}"
+- file: 
+    path: "/etc/condor/tokens.d/condor@{{ condor_host }}"
+    mode: 0600
 - name: Starting the condor service.
   service:
     name: condor


### PR DESCRIPTION
* 데몬간 IDTokens으로 기본 통신을 하기 위해 데몬용 idtoken을 생성
     * Collector와 계속 approve 요청을 하는 이슈 해결