### PR TITLE
HTCondor RPM GPG Key 관련 문제 해결

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,14 +1,4 @@
 ---
-- name: 01-cluster.conf for htcondor
-  template:
-    src: 01-cluster.conf.j2
-    dest: /etc/condor/config.d/01-cluster.conf
-  notify: restart condor
-- name: 02-local.conf for htcondor
-  template:
-    src: 02-local.conf.j2
-    dest: /etc/condor/config.d/02-local.conf
-  notify: restart condor
 - name: Check Pool password file
   stat:
     path: "{{ condor_pool_password_file_path }}"
@@ -30,6 +20,16 @@
 - file: 
     path: "/etc/condor/tokens.d/condor@{{ condor_host }}"
     mode: 0600
+- name: 01-cluster.conf for htcondor
+  template:
+    src: 01-cluster.conf.j2
+    dest: /etc/condor/config.d/01-cluster.conf
+  notify: restart condor
+- name: 02-local.conf for htcondor
+  template:
+    src: 02-local.conf.j2
+    dest: /etc/condor/config.d/02-local.conf
+  notify: restart condor
 - name: Starting the condor service.
   service:
     name: condor

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,13 +16,13 @@
     state: present
 - name: Download htcondor repository
   dnf:
-    name: "https://research.cs.wisc.edu/htcondor/repo/{{ condor_version }}/htcondor-release-current.el{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+    name: "https://research.cs.wisc.edu/htcondor/repo/{{ condor_version }}/htcondor-release-current.el{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
   when: 
 - name: Enable powertools repo for CentOS8 variation.
   command: dnf config-manager --set-enabled powertools
   when:
-    - ansible_facts['distribution_major_version'] == "8"
+    - ansible_distribution_major_version == "8"
     - (ansible_distribution == "AlmaLinux") or (ansible_distribution == "Rocky") or (ansible_distribution == "CentOS")
 - name: Install htcondor package.
   yum:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,13 +1,12 @@
 ---
 - name: Install signed key
   rpm_key:
-    key: https://research.cs.wisc.edu/htcondor/yum/RPM-GPG-KEY-HTCondor
+    key: "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-{{ condor_version }}-Key"
     state: present
 - name: Download htcondor repository
-  yum:
+  dnf:
     name: "https://research.cs.wisc.edu/htcondor/repo/{{ condor_version }}/htcondor-release-current.el{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
     state: present
-    disable_gpg_check: true
   when: ansible_facts['distribution_file_variety'] == "RedHat"
 - name: Enable powertools repo for CentOS8 variation.
   command: dnf config-manager --set-enabled powertools

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,15 @@
 ---
+- name: OS Check
+  assert: 
+    that:
+      - "ansible_os_family == 'RedHat'"
+    fail_msg: "OS must be Redhat variation"
+- name: HTCondor Version
+  assert:
+    that:
+      - (condor_version == "10.x")
+    fail_msg: "condor_version must be 10.x on Redhat 9 various"
+  when: ansible_distribution_major_version == "9"
 - name: Install signed key
   rpm_key:
     key: "https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-{{ condor_version }}-Key"
@@ -7,7 +18,9 @@
   dnf:
     name: "https://research.cs.wisc.edu/htcondor/repo/{{ condor_version }}/htcondor-release-current.el{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
     state: present
-  when: ansible_facts['distribution_file_variety'] == "RedHat"
+  when: 
+    - ansible_facts['distribution_file_variety'] == "RedHat"
+    - ansible_facts['distribution_major_version'] < 9 || condor_version == "10.x"
 - name: Enable powertools repo for CentOS8 variation.
   command: dnf config-manager --set-enabled powertools
   when:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,12 +19,9 @@
     name: "https://research.cs.wisc.edu/htcondor/repo/{{ condor_version }}/htcondor-release-current.el{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
     state: present
   when: 
-    - ansible_facts['distribution_file_variety'] == "RedHat"
-    - ansible_facts['distribution_major_version'] < 9 || condor_version == "10.x"
 - name: Enable powertools repo for CentOS8 variation.
   command: dnf config-manager --set-enabled powertools
   when:
-    - ansible_facts['distribution_file_variety'] == "RedHat"
     - ansible_facts['distribution_major_version'] == "8"
     - (ansible_distribution == "AlmaLinux") or (ansible_distribution == "Rocky") or (ansible_distribution == "CentOS")
 - name: Install htcondor package.


### PR DESCRIPTION
* OS 버전이 최신일 경우, 예전 HTCondor RPM GPG Key가 정상적으로 import 되지 않습니다.
   * 상위버전의 경우 개별 RPM GPG 키가 따로 있어 이를 지정해줍니다. (10.0 10.x 등.)